### PR TITLE
Configure acceptance testing for experimental env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -354,6 +354,10 @@ workflows:
           requires:
             - pre_deps_golang
 
+      - acceptance_tests_experimental:
+          requires:
+            - pre_deps_golang
+
       - server_test:
           requires:
             - pre_deps_golang

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,6 +310,31 @@ jobs:
           repo: orders-migrations
       - announce_failure
 
+
+  # `acceptance_tests_experimental` runs acceptance tests for the webserver against the experimental environment.
+  acceptance_tests_experimental:
+    executor: milmove_orders_medium
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}
+      - run:
+          name: Run acceptance tests
+          command: make acceptance_test
+          environment:
+            CHAMBER_RETRIES: 20
+            DB_REGION: us-west-2
+            DB_RETRY_INTERVAL: 5s
+            DEVLOCAL_CA: /home/circleci/transcom/mymove/config/tls/devlocal-ca.pem
+            DOD_CA_PACKAGE: /home/circleci/transcom/mymove/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b
+            ENV: test
+            ENVIRONMENT: experimental
+            MUTUAL_TLS_ENABLED: true
+            PWD: /home/circleci/milmove_orders
+            TEST_ACC_ENV: experimental
+      - announce_failure
+
 workflows:
   version: 2
 

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ bin/rds-ca-2019-root.pem:
 ### Orders Targets
 
 bin/orders:
-	go build -gcflags="$(GOLAND_GC_FLAGS) $(GC_FLAGS)" -asmflags=-trimpath=$(GOPATH) -ldflags "$(LDFLAGS) $(WEBSERVER_LDFLAGS)" -o bin/orders ./cmd/orders
+	go build -gcflags="$(GC_FLAGS)" -asmflags=-trimpath=$(GOPATH) -ldflags "$(LDFLAGS) $(WEBSERVER_LDFLAGS)" -o bin/orders ./cmd/orders
 
 #
 # ----- END BIN TARGETS -----
@@ -143,20 +143,10 @@ ifndef TEST_ACC_ENV
 	MUTUAL_TLS_ENABLED=true \
 	go test -v -count 1 -short $$(go list ./... | grep \\/cmd\\/orders)
 else
-ifndef CIRCLECI
 	@echo "Running acceptance tests for webserver with environment $$TEST_ACC_ENV."
 	TEST_ACC_CWD=$(PWD) \
-	DISABLE_AWS_VAULT_WRAPPER=1 \
-	aws-vault exec $(AWS_PROFILE) -- \
-	chamber -r $(CHAMBER_RETRIES) exec app-$(TEST_ACC_ENV) -- \
+	chamber -r $(CHAMBER_RETRIES) exec orders-$(TEST_ACC_ENV) -- \
 	go test -v -count 1 -short $$(go list ./... | grep \\/cmd\\/orders)
-else
-	go build -ldflags "$(LDFLAGS)" -o bin/chamber github.com/segmentio/chamber/v2
-	@echo "Running acceptance tests for webserver with environment $$TEST_ACC_ENV."
-	TEST_ACC_CWD=$(PWD) \
-	bin/chamber -r $(CHAMBER_RETRIES) exec app-$(TEST_ACC_ENV) -- \
-	go test -v -count 1 -short $$(go list ./... | grep \\/cmd\\/orders)
-endif
 endif
 
 #

--- a/cmd/orders/main_test.go
+++ b/cmd/orders/main_test.go
@@ -121,7 +121,7 @@ func (suite *webServerSuite) patchContext(ctx map[string]string) map[string]stri
 		}
 		// Overwrite the migration path to something on the local system
 		if k == "MIGRATION_PATH" {
-			ctx[k] = "file:///home/circleci/transcom/milmove_orders/migrations/orders/schema;file:///home/circleci/transcom/milmove_orders/migrations/orders/secure"
+			ctx[k] = "file:///home/circleci/milmove_orders/migrations/orders/schema;file:///home/circleci/milmove_orders/migrations/orders/secure"
 		}
 	}
 	return ctx

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -36,6 +36,7 @@ services:
       - AWS_SECURITY_TOKEN
       - AWS_SESSION_EXPIRATION
       - AWS_SESSION_TOKEN
+      - CHAMBER_RETRIES=20
       - DB_DEBUG=1
       - DB_ENV=development
       - DB_HOST=database
@@ -45,6 +46,7 @@ services:
       - DB_NAME_TEST=test_db
       - DB_PASSWORD=mysecretpassword
       - DB_PORT=5432
+      - DB_REGION=us-west-2
       - DB_RETRY_INTERVAL=5s
       - DB_SSL_MODE=disable
       - DB_USER=postgres


### PR DESCRIPTION
## Description

Before we can start deploying anything for experimental environment we need acceptance testing. This verifies that our `*.env` files and our secrets in AWS SSM (chamber) are all configured appropriately or set.

## Setup

Get into docker:

```sh
make dev
```

Test it out!

```sh
chamber list orders-experimental
TEST_ACC_ENV=experimental make acceptance_test
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.