### PR TITLE
Add bash history to docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
+# bash
+.bash_history
+
 # direnv
 .envrc.local
 .envrc.chamber

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# bash
+.bash_history
+
 # direnv
 .envrc.local
 .envrc.chamber

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -57,6 +57,9 @@ services:
       - GO111MODULE=auto
       - GOLANGCI_LINT_CONCURRENCY=6
       - GOLANGCI_LINT_VERBOSE=
+      - HISTFILE=/home/circleci/milmove_orders/.bash_history
+      - HISTFILESIZE=5000
+      - HISTSIZE=5000
       - HTTP_ORDERS_SERVER_NAME=orderslocal
       - IWS_RBS_ENABLED=0
       - IWS_RBS_HOST=pkict.dmdc.osd.mil


### PR DESCRIPTION
## Description

The ability to look back on commands is important between invocations of `make dev`. Store this in `.bash_history` and ignore it in git.