### PR TITLE
Return timespan for counted orders as part of data structure.

### DIFF
--- a/cmd/orders-api-client/get_orders_count.go
+++ b/cmd/orders-api-client/get_orders_count.go
@@ -28,7 +28,7 @@ const (
 
 func initGetOrdersCountFlags(flag *pflag.FlagSet) {
 	flag.String(IssuerFlag, "navy", "The Issuer of the orders")
-	flag.Duration(RelativeTimeFlag, time.Hour*24, "The relative time to search backwards from when the command is invoked, set to 0 to disable")
+	flag.Duration(RelativeTimeFlag, time.Hour*24, "The relative time to search backwards from when the command is invoked, set to '-1m' to disable")
 	flag.String(StartTimestampFlag, "", "The Start time to search from, overrides relative-time search")
 	flag.String(EndTimestampFlag, "", "The End time to search to, overrides relative-time search")
 

--- a/pkg/gen/ordersapi/embedded_spec.go
+++ b/pkg/gen/ordersapi/embedded_spec.go
@@ -513,6 +513,7 @@ func init() {
           "description": "Search date-time end",
           "type": "string",
           "format": "date-time",
+          "x-nullable": true,
           "example": "2020-03-01T13:19:56-04:00"
         },
         "issuer": {
@@ -522,6 +523,7 @@ func init() {
           "description": "Search date-time start",
           "type": "string",
           "format": "date-time",
+          "x-nullable": true,
           "example": "2020-03-01T13:19:56-04:00"
         }
       }
@@ -1277,6 +1279,7 @@ func init() {
           "description": "Search date-time end",
           "type": "string",
           "format": "date-time",
+          "x-nullable": true,
           "example": "2020-03-01T13:19:56-04:00"
         },
         "issuer": {
@@ -1286,6 +1289,7 @@ func init() {
           "description": "Search date-time start",
           "type": "string",
           "format": "date-time",
+          "x-nullable": true,
           "example": "2020-03-01T13:19:56-04:00"
         }
       }

--- a/pkg/gen/ordersapi/embedded_spec.go
+++ b/pkg/gen/ordersapi/embedded_spec.go
@@ -98,6 +98,20 @@ func init() {
             "name": "issuer",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "format": "date-time",
+            "description": "Search date-time start",
+            "name": "startDateTime",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "date-time",
+            "description": "Search date-time end",
+            "name": "endDateTime",
+            "in": "query"
           }
         ],
         "responses": {
@@ -495,8 +509,20 @@ func init() {
           "description": "The number of orders in the DB by issuer.\n",
           "type": "integer"
         },
+        "endDateTime": {
+          "description": "Search date-time end",
+          "type": "string",
+          "format": "date-time",
+          "example": "2020-03-01T13:19:56-04:00"
+        },
         "issuer": {
           "$ref": "#/definitions/Issuer"
+        },
+        "startDateTime": {
+          "description": "Search date-time start",
+          "type": "string",
+          "format": "date-time",
+          "example": "2020-03-01T13:19:56-04:00"
         }
       }
     },
@@ -835,6 +861,20 @@ func init() {
             "name": "issuer",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "format": "date-time",
+            "description": "Search date-time start",
+            "name": "startDateTime",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "date-time",
+            "description": "Search date-time end",
+            "name": "endDateTime",
+            "in": "query"
           }
         ],
         "responses": {
@@ -1233,8 +1273,20 @@ func init() {
           "type": "integer",
           "minimum": 0
         },
+        "endDateTime": {
+          "description": "Search date-time end",
+          "type": "string",
+          "format": "date-time",
+          "example": "2020-03-01T13:19:56-04:00"
+        },
         "issuer": {
           "$ref": "#/definitions/Issuer"
+        },
+        "startDateTime": {
+          "description": "Search date-time start",
+          "type": "string",
+          "format": "date-time",
+          "example": "2020-03-01T13:19:56-04:00"
         }
       }
     },

--- a/pkg/gen/ordersapi/ordersoperations/get_orders_count_by_issuer_parameters.go
+++ b/pkg/gen/ordersapi/ordersoperations/get_orders_count_by_issuer_parameters.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/validate"
 
@@ -31,11 +32,19 @@ type GetOrdersCountByIssuerParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
+	/*Search date-time end
+	  In: query
+	*/
+	EndDateTime *strfmt.DateTime
 	/*Organization that issued the Orders.
 	  Required: true
 	  In: path
 	*/
 	Issuer string
+	/*Search date-time start
+	  In: query
+	*/
+	StartDateTime *strfmt.DateTime
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -47,13 +56,61 @@ func (o *GetOrdersCountByIssuerParams) BindRequest(r *http.Request, route *middl
 
 	o.HTTPRequest = r
 
+	qs := runtime.Values(r.URL.Query())
+
+	qEndDateTime, qhkEndDateTime, _ := qs.GetOK("endDateTime")
+	if err := o.bindEndDateTime(qEndDateTime, qhkEndDateTime, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	rIssuer, rhkIssuer, _ := route.Params.GetOK("issuer")
 	if err := o.bindIssuer(rIssuer, rhkIssuer, route.Formats); err != nil {
 		res = append(res, err)
 	}
 
+	qStartDateTime, qhkStartDateTime, _ := qs.GetOK("startDateTime")
+	if err := o.bindStartDateTime(qStartDateTime, qhkStartDateTime, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+// bindEndDateTime binds and validates parameter EndDateTime from query.
+func (o *GetOrdersCountByIssuerParams) bindEndDateTime(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	// Format: date-time
+	value, err := formats.Parse("date-time", raw)
+	if err != nil {
+		return errors.InvalidType("endDateTime", "query", "strfmt.DateTime", raw)
+	}
+	o.EndDateTime = (value.(*strfmt.DateTime))
+
+	if err := o.validateEndDateTime(formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateEndDateTime carries on validations for parameter EndDateTime
+func (o *GetOrdersCountByIssuerParams) validateEndDateTime(formats strfmt.Registry) error {
+
+	if err := validate.FormatOf("endDateTime", "query", "date-time", o.EndDateTime.String(), formats); err != nil {
+		return err
 	}
 	return nil
 }
@@ -84,5 +141,41 @@ func (o *GetOrdersCountByIssuerParams) validateIssuer(formats strfmt.Registry) e
 		return err
 	}
 
+	return nil
+}
+
+// bindStartDateTime binds and validates parameter StartDateTime from query.
+func (o *GetOrdersCountByIssuerParams) bindStartDateTime(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	// Format: date-time
+	value, err := formats.Parse("date-time", raw)
+	if err != nil {
+		return errors.InvalidType("startDateTime", "query", "strfmt.DateTime", raw)
+	}
+	o.StartDateTime = (value.(*strfmt.DateTime))
+
+	if err := o.validateStartDateTime(formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateStartDateTime carries on validations for parameter StartDateTime
+func (o *GetOrdersCountByIssuerParams) validateStartDateTime(formats strfmt.Registry) error {
+
+	if err := validate.FormatOf("startDateTime", "query", "date-time", o.StartDateTime.String(), formats); err != nil {
+		return err
+	}
 	return nil
 }

--- a/pkg/gen/ordersapi/ordersoperations/get_orders_count_by_issuer_urlbuilder.go
+++ b/pkg/gen/ordersapi/ordersoperations/get_orders_count_by_issuer_urlbuilder.go
@@ -10,11 +10,16 @@ import (
 	"net/url"
 	golangswaggerpaths "path"
 	"strings"
+
+	"github.com/go-openapi/strfmt"
 )
 
 // GetOrdersCountByIssuerURL generates an URL for the get orders count by issuer operation
 type GetOrdersCountByIssuerURL struct {
 	Issuer string
+
+	EndDateTime   *strfmt.DateTime
+	StartDateTime *strfmt.DateTime
 
 	_basePath string
 	// avoid unkeyed usage
@@ -54,6 +59,26 @@ func (o *GetOrdersCountByIssuerURL) Build() (*url.URL, error) {
 		_basePath = "/orders/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
+
+	qs := make(url.Values)
+
+	var endDateTimeQ string
+	if o.EndDateTime != nil {
+		endDateTimeQ = o.EndDateTime.String()
+	}
+	if endDateTimeQ != "" {
+		qs.Set("endDateTime", endDateTimeQ)
+	}
+
+	var startDateTimeQ string
+	if o.StartDateTime != nil {
+		startDateTimeQ = o.StartDateTime.String()
+	}
+	if startDateTimeQ != "" {
+		qs.Set("startDateTime", startDateTimeQ)
+	}
+
+	_result.RawQuery = qs.Encode()
 
 	return &_result, nil
 }

--- a/pkg/gen/ordersclient/operations/get_orders_count_by_issuer_parameters.go
+++ b/pkg/gen/ordersclient/operations/get_orders_count_by_issuer_parameters.go
@@ -61,11 +61,21 @@ for the get orders count by issuer operation typically these are written to a ht
 */
 type GetOrdersCountByIssuerParams struct {
 
+	/*EndDateTime
+	  Search date-time end
+
+	*/
+	EndDateTime *strfmt.DateTime
 	/*Issuer
 	  Organization that issued the Orders.
 
 	*/
 	Issuer string
+	/*StartDateTime
+	  Search date-time start
+
+	*/
+	StartDateTime *strfmt.DateTime
 
 	timeout    time.Duration
 	Context    context.Context
@@ -105,6 +115,17 @@ func (o *GetOrdersCountByIssuerParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithEndDateTime adds the endDateTime to the get orders count by issuer params
+func (o *GetOrdersCountByIssuerParams) WithEndDateTime(endDateTime *strfmt.DateTime) *GetOrdersCountByIssuerParams {
+	o.SetEndDateTime(endDateTime)
+	return o
+}
+
+// SetEndDateTime adds the endDateTime to the get orders count by issuer params
+func (o *GetOrdersCountByIssuerParams) SetEndDateTime(endDateTime *strfmt.DateTime) {
+	o.EndDateTime = endDateTime
+}
+
 // WithIssuer adds the issuer to the get orders count by issuer params
 func (o *GetOrdersCountByIssuerParams) WithIssuer(issuer string) *GetOrdersCountByIssuerParams {
 	o.SetIssuer(issuer)
@@ -116,6 +137,17 @@ func (o *GetOrdersCountByIssuerParams) SetIssuer(issuer string) {
 	o.Issuer = issuer
 }
 
+// WithStartDateTime adds the startDateTime to the get orders count by issuer params
+func (o *GetOrdersCountByIssuerParams) WithStartDateTime(startDateTime *strfmt.DateTime) *GetOrdersCountByIssuerParams {
+	o.SetStartDateTime(startDateTime)
+	return o
+}
+
+// SetStartDateTime adds the startDateTime to the get orders count by issuer params
+func (o *GetOrdersCountByIssuerParams) SetStartDateTime(startDateTime *strfmt.DateTime) {
+	o.StartDateTime = startDateTime
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *GetOrdersCountByIssuerParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -124,9 +156,41 @@ func (o *GetOrdersCountByIssuerParams) WriteToRequest(r runtime.ClientRequest, r
 	}
 	var res []error
 
+	if o.EndDateTime != nil {
+
+		// query param endDateTime
+		var qrEndDateTime strfmt.DateTime
+		if o.EndDateTime != nil {
+			qrEndDateTime = *o.EndDateTime
+		}
+		qEndDateTime := qrEndDateTime.String()
+		if qEndDateTime != "" {
+			if err := r.SetQueryParam("endDateTime", qEndDateTime); err != nil {
+				return err
+			}
+		}
+
+	}
+
 	// path param issuer
 	if err := r.SetPathParam("issuer", o.Issuer); err != nil {
 		return err
+	}
+
+	if o.StartDateTime != nil {
+
+		// query param startDateTime
+		var qrStartDateTime strfmt.DateTime
+		if o.StartDateTime != nil {
+			qrStartDateTime = *o.StartDateTime
+		}
+		qStartDateTime := qrStartDateTime.String()
+		if qStartDateTime != "" {
+			if err := r.SetQueryParam("startDateTime", qStartDateTime); err != nil {
+				return err
+			}
+		}
+
 	}
 
 	if len(res) > 0 {

--- a/pkg/gen/ordersmessages/orders_count_by_issuer.go
+++ b/pkg/gen/ordersmessages/orders_count_by_issuer.go
@@ -22,9 +22,17 @@ type OrdersCountByIssuer struct {
 	// Minimum: 0
 	Count *int64 `json:"count"`
 
+	// Search date-time end
+	// Format: date-time
+	EndDateTime strfmt.DateTime `json:"endDateTime,omitempty"`
+
 	// issuer
 	// Required: true
 	Issuer Issuer `json:"issuer"`
+
+	// Search date-time start
+	// Format: date-time
+	StartDateTime strfmt.DateTime `json:"startDateTime,omitempty"`
 }
 
 // Validate validates this orders count by issuer
@@ -35,7 +43,15 @@ func (m *OrdersCountByIssuer) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateEndDateTime(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateIssuer(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateStartDateTime(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -58,12 +74,38 @@ func (m *OrdersCountByIssuer) validateCount(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *OrdersCountByIssuer) validateEndDateTime(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.EndDateTime) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("endDateTime", "body", "date-time", m.EndDateTime.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (m *OrdersCountByIssuer) validateIssuer(formats strfmt.Registry) error {
 
 	if err := m.Issuer.Validate(formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("issuer")
 		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *OrdersCountByIssuer) validateStartDateTime(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.StartDateTime) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("startDateTime", "body", "date-time", m.StartDateTime.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/gen/ordersmessages/orders_count_by_issuer.go
+++ b/pkg/gen/ordersmessages/orders_count_by_issuer.go
@@ -24,7 +24,7 @@ type OrdersCountByIssuer struct {
 
 	// Search date-time end
 	// Format: date-time
-	EndDateTime strfmt.DateTime `json:"endDateTime,omitempty"`
+	EndDateTime *strfmt.DateTime `json:"endDateTime,omitempty"`
 
 	// issuer
 	// Required: true
@@ -32,7 +32,7 @@ type OrdersCountByIssuer struct {
 
 	// Search date-time start
 	// Format: date-time
-	StartDateTime strfmt.DateTime `json:"startDateTime,omitempty"`
+	StartDateTime *strfmt.DateTime `json:"startDateTime,omitempty"`
 }
 
 // Validate validates this orders count by issuer

--- a/pkg/handlers/ordersapi/get_orders_count_by_issuer.go
+++ b/pkg/handlers/ordersapi/get_orders_count_by_issuer.go
@@ -51,7 +51,7 @@ func (h GetOrdersCountByIssuerHandler) Handle(params ordersoperations.GetOrdersC
 
 	ordersCountByIssuerPayload := &ordersmessages.OrdersCountByIssuer{
 		Issuer:        ordersmessages.Issuer(params.Issuer),
-		Count:         &ordersCountByIssuer.Count,
+		Count:         ordersCountByIssuer,
 		StartDateTime: params.StartDateTime,
 		EndDateTime:   params.EndDateTime,
 	}

--- a/pkg/handlers/ordersapi/get_orders_count_by_issuer.go
+++ b/pkg/handlers/ordersapi/get_orders_count_by_issuer.go
@@ -31,7 +31,7 @@ func (h GetOrdersCountByIssuerHandler) Handle(params ordersoperations.GetOrdersC
 		return handlers.ResponseForError(logger, errors.WithMessage(models.ErrFetchForbidden, "Not permitted to access this API"))
 	}
 
-	count, err := models.FetchElectronicOrderCountByIssuer(h.DB(), params.Issuer)
+	ordersCountByIssuer, err := models.FetchElectronicOrderCountByIssuer(h.DB(), params.Issuer)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}
@@ -40,10 +40,11 @@ func (h GetOrdersCountByIssuerHandler) Handle(params ordersoperations.GetOrdersC
 		return handlers.ResponseForError(logger, errors.WithMessage(models.ErrFetchForbidden, "Not permitted to read Orders from this issuer"))
 	}
 
-	count64 := int64(count)
 	ordersCountByIssuerPayload := &ordersmessages.OrdersCountByIssuer{
-		Issuer: ordersmessages.Issuer(params.Issuer),
-		Count:  &count64,
+		Issuer:        ordersmessages.Issuer(params.Issuer),
+		Count:         &ordersCountByIssuer.Count,
+		StartDateTime: *handlers.FmtDateTimePtr(&ordersCountByIssuer.StartDateTime),
+		EndDateTime:   *handlers.FmtDateTimePtr(&ordersCountByIssuer.EndDateTime),
 	}
 
 	return ordersoperations.NewGetOrdersCountByIssuerOK().WithPayload(ordersCountByIssuerPayload)

--- a/pkg/handlers/ordersapi/get_orders_count_by_issuer.go
+++ b/pkg/handlers/ordersapi/get_orders_count_by_issuer.go
@@ -31,7 +31,16 @@ func (h GetOrdersCountByIssuerHandler) Handle(params ordersoperations.GetOrdersC
 		return handlers.ResponseForError(logger, errors.WithMessage(models.ErrFetchForbidden, "Not permitted to access this API"))
 	}
 
-	ordersCountByIssuer, err := models.FetchElectronicOrderCountByIssuer(h.DB(), params.Issuer)
+	var startDateTime, endDateTime *string
+	if params.StartDateTime != nil {
+		dt := params.StartDateTime.String()
+		startDateTime = &dt
+	}
+	if params.EndDateTime != nil {
+		dt := params.EndDateTime.String()
+		endDateTime = &dt
+	}
+	ordersCountByIssuer, err := models.FetchElectronicOrderCountByIssuer(h.DB(), params.Issuer, startDateTime, endDateTime)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}
@@ -43,8 +52,8 @@ func (h GetOrdersCountByIssuerHandler) Handle(params ordersoperations.GetOrdersC
 	ordersCountByIssuerPayload := &ordersmessages.OrdersCountByIssuer{
 		Issuer:        ordersmessages.Issuer(params.Issuer),
 		Count:         &ordersCountByIssuer.Count,
-		StartDateTime: *handlers.FmtDateTimePtr(&ordersCountByIssuer.StartDateTime),
-		EndDateTime:   *handlers.FmtDateTimePtr(&ordersCountByIssuer.EndDateTime),
+		StartDateTime: params.StartDateTime,
+		EndDateTime:   params.EndDateTime,
 	}
 
 	return ordersoperations.NewGetOrdersCountByIssuerOK().WithPayload(ordersCountByIssuerPayload)

--- a/pkg/models/electronic_order_test.go
+++ b/pkg/models/electronic_order_test.go
@@ -170,9 +170,9 @@ func (suite *ModelSuite) TestFetchElectronicOrdersCountByIssuer() {
 
 	countArmy, err := models.FetchElectronicOrderCountByIssuer(suite.DB(), string(models.IssuerArmy))
 	suite.NoError(err)
-	suite.Equal(countArmy, 1)
+	suite.Equal(countArmy.Count, 1)
 
 	countAirForce, err := models.FetchElectronicOrderCountByIssuer(suite.DB(), string(models.IssuerAirForce))
 	suite.NoError(err)
-	suite.Equal(countAirForce, 1)
+	suite.Equal(countAirForce.Count, 1)
 }

--- a/pkg/models/electronic_order_test.go
+++ b/pkg/models/electronic_order_test.go
@@ -168,11 +168,11 @@ func (suite *ModelSuite) TestFetchElectronicOrdersCountByIssuer() {
 	suite.NoError(err)
 	suite.NoVerrs(verrs)
 
-	countArmy, err := models.FetchElectronicOrderCountByIssuer(suite.DB(), string(models.IssuerArmy))
+	countArmy, err := models.FetchElectronicOrderCountByIssuer(suite.DB(), string(models.IssuerArmy), nil, nil)
 	suite.NoError(err)
-	suite.Equal(countArmy.Count, 1)
+	suite.Equal(int64(1), countArmy.Count)
 
-	countAirForce, err := models.FetchElectronicOrderCountByIssuer(suite.DB(), string(models.IssuerAirForce))
+	countAirForce, err := models.FetchElectronicOrderCountByIssuer(suite.DB(), string(models.IssuerAirForce), nil, nil)
 	suite.NoError(err)
-	suite.Equal(countAirForce.Count, 1)
+	suite.Equal(int64(1), countAirForce.Count)
 }

--- a/pkg/models/electronic_order_test.go
+++ b/pkg/models/electronic_order_test.go
@@ -170,9 +170,9 @@ func (suite *ModelSuite) TestFetchElectronicOrdersCountByIssuer() {
 
 	countArmy, err := models.FetchElectronicOrderCountByIssuer(suite.DB(), string(models.IssuerArmy), nil, nil)
 	suite.NoError(err)
-	suite.Equal(int64(1), countArmy.Count)
+	suite.Equal(int64(1), *countArmy)
 
 	countAirForce, err := models.FetchElectronicOrderCountByIssuer(suite.DB(), string(models.IssuerAirForce), nil, nil)
 	suite.NoError(err)
-	suite.Equal(int64(1), countAirForce.Count)
+	suite.Equal(int64(1), *countAirForce)
 }

--- a/swagger/orders.yaml
+++ b/swagger/orders.yaml
@@ -67,6 +67,16 @@ paths:
             - air-force
             - marine-corps
             - coast-guard
+        - name: startDateTime
+          in: query
+          description: Search date-time start
+          type: string
+          format: date-time
+        - name: endDateTime
+          in: query
+          description: Search date-time end
+          type: string
+          format: date-time
       responses:
         '200':
           description: Successful
@@ -861,6 +871,16 @@ definitions:
           The number of orders in the DB by issuer.
       issuer:
         $ref: '#/definitions/Issuer'
+      startDateTime:
+        type: string
+        description: Search date-time start
+        format: date-time
+        example: '2020-03-01T13:19:56-04:00'
+      endDateTime:
+        type: string
+        description: Search date-time end
+        format: date-time
+        example: '2020-03-01T13:19:56-04:00'
     required:
       - count
       - issuer

--- a/swagger/orders.yaml
+++ b/swagger/orders.yaml
@@ -876,11 +876,13 @@ definitions:
         description: Search date-time start
         format: date-time
         example: '2020-03-01T13:19:56-04:00'
+        x-nullable: true
       endDateTime:
         type: string
         description: Search date-time end
         format: date-time
         example: '2020-03-01T13:19:56-04:00'
+        x-nullable: true
     required:
       - count
       - issuer


### PR DESCRIPTION
## Description

Before uploading fake orders to Experimental I want to be able to confirm data I uploaded is there and was created during the time period I expected. This adds an extra set of query parameters to the CLI and API so that I can do just that.

## Setup

Load data:

```
make dev_up
make dev
make db_dev_migrate
orders-api-client --insecure --hostname orderslocal --port 7443 --certpath config/tls/devlocal-faux-navy-orders.cer --keypath config/tls/devlocal-faux-navy-orders.key  post-revisions --csv-file nom_demo_20190404.csv
```

Some examples in no particular order:

```sh
# Start and End time
go run github.com/transcom/milmove_orders/cmd/orders-api-client --insecure --hostname orderslocal --port 7443 --certpath config/tls/devlocal-faux-navy-orders.cer --keypath config/tls/devlocal-faux-navy-orders.key get-orders-count --issuer navy --end-time "2020-03-16T22:16:19.552Z" --start-time "2020-03-16T17:16:19.552Z"

# End time only
go run github.com/transcom/milmove_orders/cmd/orders-api-client --insecure --hostname orderslocal --port 7443 --certpath config/tls/devlocal-faux-navy-orders.cer --keypath config/tls/devlocal-faux-navy-orders.key get-orders-count --issuer navy --end-time "2020-03-16T22:16:19.552Z"

# Start time only
go run github.com/transcom/milmove_orders/cmd/orders-api-client --insecure --hostname orderslocal --port 7443 --certpath config/tls/devlocal-faux-navy-orders.cer --keypath config/tls/devlocal-faux-navy-orders.key get-orders-count --issuer navy --start-time "2020-03-16T17:16:19.552Z"

# Fallback to 24h relative time query (default)
go run github.com/transcom/milmove_orders/cmd/orders-api-client --insecure --hostname orderslocal --port 7443 --certpath config/tls/devlocal-faux-navy-orders.cer --keypath config/tls/devlocal-faux-navy-orders.key get-orders-count --issuer navy

# Disable relative time query and get all-time count
go run github.com/transcom/milmove_orders/cmd/orders-api-client --insecure --hostname orderslocal --port 7443 --certpath config/tls/devlocal-faux-navy-orders.cer --keypath config/tls/devlocal-faux-navy-orders.key get-orders-count --issuer navy --relative-time -1m
```

## Code Review Verification Steps

* [x] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
