### PR TITLE
Set Up RDS IAM for Orders DB

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -502,7 +502,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: cg_rds_iam
 
       - build_orders:
           requires:
@@ -528,14 +528,14 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_rds_iam
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_rds_iam
 
 experimental:
   notify:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -502,7 +502,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: cg_rds_iam
+              ignore: placeholder_branch_name
 
       - build_orders:
           requires:
@@ -528,14 +528,14 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: cg_rds_iam
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_rds_iam
+              only: placeholder_branch_name
 
 experimental:
   notify:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,10 +20,10 @@ echo "Code goes here"
 * [ ] The requirements listed in
  [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
  have been satisfied.
-* Any new migrations/schema changes:
+* [ ] Any new migrations/schema changes:
   * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
   * [ ] Have been communicated to #prac-engineering
-  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
+  * [ ] Secure migrations have been tested locally with commands like `make run_experimental_migrations`
 * [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
 * [ ] Request review from a member of a different team.
 * [ ] Have the Jira acceptance criteria been met for this change?

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ dev_reset_server: ## Reset running server
 .PHONY: clean
 clean: ## Clean all generated files
 	rm -rf ./bin
-	rm -rf ./tmp/secure_migrations
+	rm -rf ./tmp
 	rm -rf ./log
 
 #

--- a/migrations/orders/migrations_manifest.txt
+++ b/migrations/orders/migrations_manifest.txt
@@ -1,5 +1,8 @@
 # This is the migrations manifest.
 # If a migration is not recorded here, then it will error.
+20200210000000_rds_iam_role.up.sql
+20200210000001_master_role.up.sql
+20200210000002_ecs_user_for_rds.up.sql
 20200211000001_create_client_cert_table.up.sql
 20200211000002_create_electronic_orders.up.sql
 20200211000003_create_electronic_orders_revisions.up.sql

--- a/migrations/orders/schema/20200210000000_rds_iam_role.up.sql
+++ b/migrations/orders/schema/20200210000000_rds_iam_role.up.sql
@@ -1,0 +1,16 @@
+-- RDS postgres has a role named 'rds_iam' which doesn't exist in development
+-- Unfortunately it's required in development to run prod migrations.
+-- This script checks for the role's existence before creating it.
+
+-- https://stackoverflow.com/questions/8092086/create-postgresql-role-user-if-it-doesnt-exist
+DO
+$do$
+BEGIN
+  IF NOT EXISTS (
+    SELECT -- SELECT list can stay empty for this
+    FROM   pg_catalog.pg_roles
+    WHERE  rolname = 'rds_iam') THEN
+    CREATE ROLE rds_iam;
+  END IF;
+END
+$do$;

--- a/migrations/orders/schema/20200210000001_master_role.up.sql
+++ b/migrations/orders/schema/20200210000001_master_role.up.sql
@@ -1,0 +1,34 @@
+-- RDS postgres has a user named 'master' which doesn't exist in development
+-- Unfortunately it's required in development to run prod migrations.
+-- This script checks for the user's existence before creating it.
+
+-- https://stackoverflow.com/questions/8092086/create-postgresql-role-user-if-it-doesnt-exist
+DO
+$do$
+BEGIN
+  IF NOT EXISTS (
+    SELECT -- SELECT list can stay empty for this
+    FROM   pg_catalog.pg_roles
+    WHERE  rolname = 'master') THEN
+
+    -- New local user with password
+	CREATE USER master WITH PASSWORD 'mysecretpassword';
+
+    -- Local user should have same privs as primary user
+    GRANT postgres TO master;
+    -- In Production this would be
+    -- GRANT master TO ecs_user;
+
+    -- Modify existing tables, sequences, and functions
+    GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO master;
+    GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO master;
+    GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public TO master;
+
+    -- Modify future tables, sequences, and functions
+    ALTER DEFAULT PRIVILEGES FOR ROLE postgres GRANT ALL PRIVILEGES ON TABLES TO master;
+    ALTER DEFAULT PRIVILEGES FOR ROLE postgres GRANT ALL PRIVILEGES ON SEQUENCES TO master;
+    ALTER DEFAULT PRIVILEGES FOR ROLE postgres GRANT ALL PRIVILEGES ON FUNCTIONS TO master;
+
+  END IF;
+END
+$do$;

--- a/migrations/orders/secure/20200210000002_ecs_user_for_rds.up.sql
+++ b/migrations/orders/secure/20200210000002_ecs_user_for_rds.up.sql
@@ -1,0 +1,37 @@
+-- Local test migration.
+-- This will be run on development environments. It should mirror what you
+-- intend to apply on production, but do not include any sensitive data.
+
+-- https://stackoverflow.com/questions/8092086/create-postgresql-role-user-if-it-doesnt-exist
+DO
+$do$
+BEGIN
+  IF NOT EXISTS (
+    SELECT -- SELECT list can stay empty for this
+    FROM   pg_catalog.pg_roles
+    WHERE  rolname = 'ecs_user') THEN
+
+    -- New local user with password
+    -- In Production this would be
+    -- CREATE USER ecs_user WITH LOGIN;
+    CREATE USER ecs_user WITH PASSWORD 'mysecretpassword';
+
+    -- rds_iam is an empty role in development but not in production
+    GRANT rds_iam TO ecs_user;
+
+    -- Local user should have same privs as primary user
+    GRANT master TO ecs_user;
+
+    -- Modify existing tables, sequences, and functions
+    GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO ecs_user;
+    GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO ecs_user;
+    GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public TO ecs_user;
+
+    -- Modify future tables, sequences, and functions
+    ALTER DEFAULT PRIVILEGES FOR ROLE master GRANT ALL PRIVILEGES ON TABLES TO ecs_user;
+    ALTER DEFAULT PRIVILEGES FOR ROLE master GRANT ALL PRIVILEGES ON SEQUENCES TO ecs_user;
+    ALTER DEFAULT PRIVILEGES FOR ROLE master GRANT ALL PRIVILEGES ON FUNCTIONS TO ecs_user;
+
+  END IF;
+END
+$do$;

--- a/scripts/psql-deployed-migrations
+++ b/scripts/psql-deployed-migrations
@@ -1,0 +1,6 @@
+#! /usr/bin/env bash
+
+export DB_NAME=deployed_migrations
+export DB_PORT=$DB_PORT_DEPLOYED_MIGRATIONS
+# shellcheck disable=SC1091,SC1090
+. "$(dirname "$0")"/psql-wrapper

--- a/scripts/psql-test
+++ b/scripts/psql-test
@@ -1,0 +1,6 @@
+#! /usr/bin/env bash
+
+export DB_NAME=test_db
+export DB_PORT=$DB_PORT_TEST
+# shellcheck disable=SC1091,SC1090
+. "$(dirname "$0")"/psql-wrapper


### PR DESCRIPTION
## Description

Add 'master' and 'ecs_user' roles/users to DB along with new 'rds_iam' role for use with RDS IAM.

Things to note:
- `rds_iam` is a role that is special in RDS that is required for IAM to work with Postgres. For local development it is simply an empty role and we add it locally to mimic what is in RDS.
- `master` is a role in RDS and is created in this PR so we can test that role locally as though we were testing in RDS.
- `ecs_user` is the role used for connecting to the DB via RDS IAM. It has a limited set of permissions so that it can do application functions and nothing else. This prevents it from being used improperly by someone that gives themselves RDS IAM permissions.

Each migration is set up in an IF/THEN block so that migrations won't run if roles already exist.

## Setup

It's useful to compare the development DB from the transcom/mymove repo against the development DB for this repo. 

### MyMove DB

```text
# select * from pg_catalog.pg_user;
 usename  | usesysid | usecreatedb | usesuper | userepl | usebypassrls |  passwd  | valuntil | useconfig
----------+----------+-------------+----------+---------+--------------+----------+----------+-----------
 postgres |       10 | t           | t        | t       | t            | ******** | [NULL]   | [NULL]
 master   |    17445 | f           | f        | f       | f            | ******** | [NULL]   | [NULL]
 ecs_user |    17449 | f           | f        | f       | f            | ******** | [NULL]   | [NULL]
(3 rows)

# select * from pg_catalog.pg_roles where rolname in ('ecs_user', 'postgres', 'master');
 rolname  | rolsuper | rolinherit | rolcreaterole | rolcreatedb | rolcanlogin | rolreplication | rolconnlimit | rolpassword | rolvaliduntil | rolbypassrls | rolconfig |  oid
----------+----------+------------+---------------+-------------+-------------+----------------+--------------+-------------+---------------+--------------+-----------+-------
 ecs_user | f        | t          | f             | f           | t           | f              |           -1 | ********    | [NULL]        | f            | [NULL]    | 17449
 postgres | t        | t          | t             | t           | t           | t              |           -1 | ********    | [NULL]        | t            | [NULL]    |    10
 master   | f        | t          | f             | f           | t           | f              |           -1 | ********    | [NULL]        | f            | [NULL]    | 17445
(3 rows)
```

### Orders DB

```text
# select * from pg_catalog.pg_user;
 usename  | usesysid | usecreatedb | usesuper | userepl | usebypassrls |  passwd  | valuntil | useconfig
----------+----------+-------------+----------+---------+--------------+----------+----------+-----------
 postgres |       10 | t           | t        | t       | t            | ******** |          |
 master   |    23867 | f           | f        | f       | f            | ******** |          |
 ecs_user |    23871 | f           | f        | f       | f            | ******** |          |
(3 rows)

# select * from pg_catalog.pg_roles where rolname in ('ecs_user', 'postgres', 'master');
 rolname  | rolsuper | rolinherit | rolcreaterole | rolcreatedb | rolcanlogin | rolreplication | rolconnlimit | rolpassword | rolvaliduntil | rolbypassrls | rolconfig |  oid
----------+----------+------------+---------------+-------------+-------------+----------------+--------------+-------------+---------------+--------------+-----------+-------
 ecs_user | f        | t          | f             | f           | t           | f              |           -1 | ********    |               | f            |           | 23871
 postgres | t        | t          | t             | t           | t           | t              |           -1 | ********    |               | t            |           |    10
 master   | f        | t          | f             | f           | t           | f              |           -1 | ********    |               | f            |           | 23867
(3 rows)
```

### Secure Migrations

You should be able to check secure migrations by running this command:

```sh
download-secure-migrations 20200210000002_ecs_user_for_rds.up.sql
```

In particular look for this user creation **with no password**:

```sql
CREATE USER ecs_user WITH LOGIN;
```

Locally we have to create a password and it would be done like this:

```sql
CREATE USER ecs_user WITH PASSWORD 'mysecretpassword';
```

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [x] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [x] Secure migrations have been tested using `make run_experimental_migrations`
* [x] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [x] Request review from a member of a different team.
