### PR TITLE
Upgrade to postgres:11.6 as an intermediate step to 12.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -541,7 +541,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: cg_postgres_11.6
 
       - server_test:
           requires:
@@ -549,7 +549,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: cg_postgres_11.6
 
       - build_orders:
           requires:
@@ -577,14 +577,14 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_postgres_11.6
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_postgres_11.6
 
 experimental:
   notify:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -541,7 +541,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: cg_postgres_11.6
+              ignore: placeholder_branch_name
 
       - server_test:
           requires:
@@ -549,7 +549,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: cg_postgres_11.6
+              ignore: placeholder_branch_name
 
       - build_orders:
           requires:
@@ -577,14 +577,14 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: cg_postgres_11.6
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_postgres_11.6
+              only: placeholder_branch_name
 
 experimental:
   notify:

--- a/docker-compose.branch.yml
+++ b/docker-compose.branch.yml
@@ -6,7 +6,7 @@ version: '3.3'
 
 services:
   database:
-    image: postgres:10.12
+    image: postgres:11.6
     restart: always
     ports:
       - '7432:5432'

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,7 +6,7 @@ version: '3.3'
 
 services:
   database:
-    image: postgres:10.12
+    image: postgres:11.6
     restart: always
     ports:
       - '7432:5432'

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -6,7 +6,7 @@ version: '3.3'
 
 services:
   database:
-    image: postgres:10.12
+    image: postgres:11.6
     restart: always
     ports:
       - '7432:5432'


### PR DESCRIPTION
## Description

Going to test that we can use postgres 11. If tests pass we'll upgrade the RDS instance and then deploy to experimental and see what happens. If that's a success we'll merge and then do this again for postgres 12.