### PR TITLE
Use chamber inside docker for direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,7 @@
 #! /usr/bin/env bash
 
+set -eu -o pipefail
+
 ##########################################
 # DO NOT MAKE LOCAL CHANGES TO THIS FILE #
 #                                        #
@@ -98,7 +100,7 @@ export MOVE_MIL_DOD_CA_CERT
 #
 # Your AWS credentials should be setup in the transcom-ppp profile using
 # aws-vault. They will be detected and used by the app automatically.
-require AWS_ACCOUNT_ID
+require AWS_ACCOUNT_ID "Ask your admin for AWS_ACCOUNT_ID"
 export AWS_DEFAULT_REGION="us-west-2"
 
 # Anti-Virus Settings

--- a/.envrc.chamber.template
+++ b/.envrc.chamber.template
@@ -4,14 +4,35 @@
 # Load Secrets from Chamber #
 #############################
 
+set -eu -o pipefail
+
+# Run chamber inside docker container and pass through AWS creds
+function chamber_cmd () {
+  aws-vault exec "${AWS_PROFILE}" -- \
+    docker run \
+      -it \
+      --rm \
+      --entrypoint chamber \
+      -e AWS_ACCESS_KEY_ID \
+      -e AWS_ACCOUNT_ID \
+      -e AWS_REGION \
+      -e AWS_SDK_LOAD_CONFIG \
+      -e AWS_SECRET_ACCESS_KEY \
+      -e AWS_SECURITY_TOKEN \
+      -e AWS_SESSION_EXPIRATION \
+      -e AWS_SESSION_TOKEN \
+      milmove/circleci-docker:milmove-orders \
+      "$@"
+}
+
 # Secrets should be stored in the corresponding Google Doc listed in the .envrc file.
 # Secrets should also be added to chamber with `chamber write orders-devlocal lower_case_version secret_key`
 
 # This line grabs any available secrets in orders-devlocal and adds them to the environment.
 # Lines that begin with `require ...` should still run to verify the secret is set.
-if ! aws-vault exec "${AWS_PROFILE}" -- chamber list orders-devlocal --retries=1 > /dev/null ; then
+if ! chamber_cmd list orders-devlocal --retries=1 > /dev/null ; then
   log_error "Unable to access orders-devlocal variables with chamber."
   log_error "Login to chamber with 'chamber list orders-devlocal'."
 else
-  eval "$(aws-vault exec "${AWS_PROFILE}" -- chamber env orders-devlocal --retries=1)"
+  eval "$(chamber_cmd env orders-devlocal --retries=1)"
 fi


### PR DESCRIPTION
## Description

In this PR I'm looking to use docker to access the chamber binary. That means I don't have to have it installed locally on mac in order to get the variables to run the project. It also means no one has to check the installed chamber version because it comes for free in the docker container.