### PR TITLE
Fix an issue with eval and docker 

### DIFF
--- a/.envrc.chamber.template
+++ b/.envrc.chamber.template
@@ -34,5 +34,8 @@ if ! chamber_cmd list orders-devlocal --retries=1 > /dev/null ; then
   log_error "Unable to access orders-devlocal variables with chamber."
   log_error "Login to chamber with 'chamber list orders-devlocal'."
 else
-  eval "$(chamber_cmd env orders-devlocal --retries=1)"
+  # Without the newline character the last variable will include the carriage return character
+  # which in turn makes the output of the last variable erase. I believe this is an interaction
+  # between eval and docker and not with chamber itself.
+  eval "$(chamber_cmd env orders-devlocal --retries=1)\n"
 fi


### PR DESCRIPTION
## Description

A carriage return improperly cuts off any text following an env variable

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

To test this make sure you are using chamber for env vars and run:

```
direnv allow
make docker_compose_branch_up
```

Without this feature you will find that it won't work as the URL is completely cut off after the AWS account ID is added.
