### PR TITLE
MB-2182 - Upgrade postgres to 12.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ orbs:
 # References for variables shared across the file
 references:
   circleci-docker: &circleci-docker milmove/circleci-docker:milmove-orders-de8333d340c6cc5bc7554c913a955aacfa0c4d2b
-  postgres: &postgres postgres:10.12
+  postgres: &postgres postgres:12.2
 
 executors:
   av_medium:

--- a/docker-compose.branch.yml
+++ b/docker-compose.branch.yml
@@ -6,7 +6,7 @@ version: '3.3'
 
 services:
   database:
-    image: postgres:11.6
+    image: postgres:12.2
     restart: always
     ports:
       - '7432:5432'

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,7 +6,7 @@ version: '3.3'
 
 services:
   database:
-    image: postgres:11.6
+    image: postgres:12.2
     restart: always
     ports:
       - '7432:5432'

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -6,7 +6,7 @@ version: '3.3'
 
 services:
   database:
-    image: postgres:11.6
+    image: postgres:12.2
     restart: always
     ports:
       - '7432:5432'


### PR DESCRIPTION
## Description

AWS has released Postgres 12.2 so it's time to upgrade this codebase.

Needs to happen before https://github.com/transcom/ppp-infra/pull/885

## Setup

```sh
docker pull postgres:12.2
```