### PR TITLE
MB-2359 - Specify explicitly the certificates required for testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ COPY bin/orders /bin/orders
 COPY config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b /config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b
 COPY config/tls/dod-sw-ca-54.pem /config/tls/dod-sw-ca-54.pem
 
-COPY config /config
 COPY swagger/* /swagger/
 
 ENTRYPOINT ["/bin/orders"]

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -23,7 +23,13 @@ FROM gcr.io/distroless/base:latest
 COPY --from=builder --chown=root:root /home/circleci/project/bin/rds-ca-2019-root.pem /bin/rds-ca-2019-root.pem
 COPY --from=builder --chown=root:root /home/circleci/project/bin/orders /bin/orders
 
-COPY config /config
+COPY config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b /config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b
+COPY config/tls/dod-sw-ca-54.pem /config/tls/dod-sw-ca-54.pem
+
+# Certs used for testing only
+COPY config/tls/devlocal-ca.key /config/tls/devlocal-ca.key
+COPY config/tls/devlocal-ca.pem /config/tls/devlocal-ca.pem
+
 COPY swagger/* /swagger/
 
 ENTRYPOINT ["/bin/orders"]

--- a/scripts/run-e2e-test
+++ b/scripts/run-e2e-test
@@ -35,6 +35,8 @@ if [[ -n "${CIRCLECI+x}" ]]; then
   # Can't mount folders in CircleCI so copy this data in
   # https://circleci.com/docs/2.0/building-docker-images/#mounting-folders
   docker cp ./migrations/orders/secure milmove_orders_milmove_migrate_1:/migrate/
+  docker cp ./config/tls/devlocal-ca.key milmove_orders_milmove_1:/config/tls/devlocal-ca.key
+  docker cp ./config/tls/devlocal-ca.pem milmove_orders_milmove_1:/config/tls/devlocal-ca.pem
 
   # Start everything up
   docker-compose -f docker-compose.branch.yml up -d --no-recreate --remove-orphans


### PR DESCRIPTION
## Description

The fix here is to not copy in all the files in the `/config/tls/` directory and to explicitly remove them from docker container being pushed to production.