### PR TITLE
MB-2477 - Move trace and contextlogger middleware

### DIFF
--- a/cmd/orders/serve.go
+++ b/cmd/orders/serve.go
@@ -374,6 +374,9 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 	// called first).
 	site.Use(middleware.Recovery(logger))
 	site.Use(middleware.SecurityHeaders(logger))
+	site.Use(middleware.Trace(logger, &handlerContext)) // injects http request trace id
+	site.Use(middleware.ContextLogger("milmove_trace_id", logger))
+
 	if maxBodySize := v.GetInt64(cli.MaxBodySizeFlag); maxBodySize > 0 {
 		site.Use(middleware.LimitBodySize(maxBodySize, logger))
 	}
@@ -478,8 +481,6 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 
 	// Handlers under mutual TLS need to go before this section that sets up middleware that shouldn't be enabled for mutual TLS (such as CSRF)
 	root := goji.NewMux()
-	root.Use(middleware.Trace(logger, &handlerContext))            // injects http request trace id
-	root.Use(middleware.ContextLogger("milmove_trace_id", logger)) // injects http request logger
 	root.Use(middleware.RequestLogger(logger))
 
 	site.Handle(pat.New("/*"), root)


### PR DESCRIPTION
## Description

This PR copies work from https://github.com/transcom/mymove/pull/4042 by @shimonacarvalho . 

It moves the Trace and ContextLogger middleware up to the `site` from the `root` so that the Orders API can benefit from them.

## Setup

Window 1

```sh
make dev
```

Window 2

```sh
make dev_logs
```

Window 1

```sh
rm -f bin/orders && make bin/orders
make db_dev_migrate
rm -f bin/orders-api-client && make bin/orders-api-client
bin/orders-api-client --insecure --hostname orderslocal --port 7443 --certpath config/tls/devlocal-faux-all-orders.cer --keypath config/tls/devlocal-faux-all-orders.key get-orders-count --issuer navy
```

Window 1 output:

```json
{"count":0,"endDateTime":"2020-05-12T23:32:34.290Z","issuer":"navy","startDateTime":"2020-05-11T23:32:34.290Z"}
```

Window 2 logs:

```text
dev_1       | 2020-05-12T23:32:34.326Z  INFO    middleware/request_logger.go:85 Request {"git_branch": "master", "git_commit": "ba5ab441edf6100e95dd08fcabe94e32f84e3ac3", "milmove_trace_id": "571903a2-fff5-46e4-a9de-a10784ffc71b", "accepted-language": "", "content-length": 0, "host": "orderslocal:7443", "method": "GET", "protocol-version": "HTTP/1.1", "referer": "", "source": "127.0.0.1:53854", "url": "/orders/v1/issuers/navy/count?endDateTime=2020-05-12T23%3A32%3A34.290Z&startDateTime=2020-05-11T23%3A32%3A34.290Z", "user-agent": "Go-http-client/1.1", "protocol": "https", "headers": 3, "duration": "2.6823ms", "resp-size-bytes": 112, "resp-status": 200}
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.