### PR TITLE
MB-3030 - Remove cgilmer CAC access

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -559,7 +559,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: cg_remove_cgilmer_cac
+              ignore: placeholder_branch_name
 
       - server_test:
           requires:
@@ -567,7 +567,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: cg_remove_cgilmer_cac
+              ignore: placeholder_branch_name
 
       - build_orders:
           requires:
@@ -595,14 +595,14 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: cg_remove_cgilmer_cac
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_remove_cgilmer_cac
+              only: placeholder_branch_name
 
 experimental:
   notify:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,10 +81,10 @@ commands:
             source $BASH_ENV
       - run:
           name: Snapshot database
-          command: scripts/rds-snapshot-orders-db << parameters.environment >>
+          command: do-exclusively --job-name ${CIRCLE_JOB} scripts/rds-snapshot-orders-db << parameters.environment >>
       - run:
           name: Run migrations
-          command: scripts/ecs-run-orders-migrations-container "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>@${ECR_DIGEST}" << parameters.environment >>
+          command: do-exclusively --job-name ${CIRCLE_JOB} scripts/ecs-run-orders-migrations-container "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>@${ECR_DIGEST}" << parameters.environment >>
           no_output_timeout: 60m
           environment:
             CHAMBER_RETRIES: 20
@@ -117,7 +117,7 @@ commands:
             source $BASH_ENV
       - deploy:
           name: Deploy orders service
-          command: scripts/ecs-deploy-service-container orders "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>@${ECR_DIGEST}" << parameters.environment >>
+          command: do-exclusively --job-name ${CIRCLE_JOB} scripts/ecs-deploy-service-container orders "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>@${ECR_DIGEST}" << parameters.environment >>
           no_output_timeout: 20m
       - run:
           name: Health Check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,10 +81,10 @@ commands:
             source $BASH_ENV
       - run:
           name: Snapshot database
-          command: do-exclusively --job-name ${CIRCLE_JOB} scripts/rds-snapshot-orders-db << parameters.environment >>
+          command: scripts/rds-snapshot-orders-db << parameters.environment >>
       - run:
           name: Run migrations
-          command: do-exclusively --job-name ${CIRCLE_JOB} scripts/ecs-run-orders-migrations-container "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>@${ECR_DIGEST}" << parameters.environment >>
+          command: scripts/ecs-run-orders-migrations-container "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>@${ECR_DIGEST}" << parameters.environment >>
           no_output_timeout: 60m
           environment:
             CHAMBER_RETRIES: 20
@@ -117,7 +117,7 @@ commands:
             source $BASH_ENV
       - deploy:
           name: Deploy orders service
-          command: do-exclusively --job-name ${CIRCLE_JOB} scripts/ecs-deploy-service-container orders "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>@${ECR_DIGEST}" << parameters.environment >>
+          command: scripts/ecs-deploy-service-container orders "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>@${ECR_DIGEST}" << parameters.environment >>
           no_output_timeout: 20m
       - run:
           name: Health Check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -559,7 +559,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: cg_remove_cgilmer_cac
 
       - server_test:
           requires:
@@ -567,7 +567,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: cg_remove_cgilmer_cac
 
       - build_orders:
           requires:
@@ -595,14 +595,14 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_remove_cgilmer_cac
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_remove_cgilmer_cac
 
 experimental:
   notify:

--- a/migrations/orders/migrations_manifest.txt
+++ b/migrations/orders/migrations_manifest.txt
@@ -16,3 +16,4 @@
 20200219000001_erin_cac.up.sql
 20200219000002_mr337_cac.up.sql
 20200219000003_rd_cac.up.sql
+20200619120000_remove_cgilmer_cac.up.sql

--- a/migrations/orders/schema/20200619120000_remove_cgilmer_cac.up.sql
+++ b/migrations/orders/schema/20200619120000_remove_cgilmer_cac.up.sql
@@ -1,0 +1,2 @@
+-- Remove cgilmer CAC using unique sha256 digest of client cert
+DELETE FROM client_certs WHERE sha256_digest='15697aff85d93a2f04259618b66f09f9976887b3f2ee206395c42e4897aefe61';


### PR DESCRIPTION
## Description

Relates to https://github.com/transcom/mymove/pull/4299

Removes CAC access. The record of who had access for auditing is in both the git repo and the s3 bucket history. While disabling all permissions feels like an ok route to take here its just as easy for someone to re-add those permissions. And the CAC itself is going to be destroyed so removing seems more prudent.

This doesn't have to be a secure migration because we're only identifying the sha256 digest in dev/experimental/staging/prod. And if it doesn't exist in those environments this is a noop.

## Reviewer Notes

**NOTE:** This needs to be deployed manually to experimental to apply in that environment.

## Setup

```sh
make db_dev_run db_dev_migrate
```

## Code Review Verification Steps

* [x] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)