### PR TITLE
MMDM-1630 Removes cac access for rd

### DIFF
--- a/migrations/orders/migrations_manifest.txt
+++ b/migrations/orders/migrations_manifest.txt
@@ -17,3 +17,4 @@
 20200219000002_mr337_cac.up.sql
 20200219000003_rd_cac.up.sql
 20200619120000_remove_cgilmer_cac.up.sql
+20200929210500_remove_rdhariwal_cac.up.sql

--- a/migrations/orders/schema/20200929210500_remove_rdhariwal_cac.up.sql
+++ b/migrations/orders/schema/20200929210500_remove_rdhariwal_cac.up.sql
@@ -1,0 +1,2 @@
+-- Remove rdhariwal CAC using unique sha256 digest of client cert
+DELETE FROM client_certs WHERE sha256_digest='f2658a432de1f84813f4372d93873a328925df5a4fdc4ee948a025cb9520a83c';


### PR DESCRIPTION
## Description
Related to: https://github.com/transcom/mymove/pull/4880
Removes CAC access. This doesn't have to be a secure migration because we're only identifying the sha256 digest in dev/experimental/staging/prod. And if it doesn't exist in those environments this is a noop.

## Reviewer Notes
NOTE: This needs to be deployed manually to experimental to apply in that environment.

## Setup
`make db_dev_run db_dev_migrate`

