### PR TITLE
MMDM-1755 - Remove Lee's CAC access

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -559,7 +559,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: am-remove-lee-cac-access
+              ignore: placeholder_branch_name
 
       - server_test:
           requires:
@@ -567,7 +567,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: am-remove-lee-cac-access
+              ignore: placeholder_branch_name
 
       - build_orders:
           requires:
@@ -595,14 +595,14 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: am-remove-lee-cac-access
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: am-remove-lee-cac-access
+              only: placeholder_branch_name
 
 experimental:
   notify:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,7 +180,7 @@ commands:
           dockerfile: << parameters.dockerfile >>
           region: AWS_DEFAULT_REGION
           repo: << parameters.repo >>
-          tag: "git-${CIRCLE_SHA1},git-branch-${BRANCH_NAME}"
+          tag: 'git-${CIRCLE_SHA1},git-branch-${BRANCH_NAME}'
       - ecr_record_image_digest:
           repo: << parameters.repo >>
       - ecr_describe_image_scan_findings:
@@ -195,13 +195,13 @@ commands:
           name: make server_test_build for <<parameters.application>>
           command: make server_test_build
           environment:
-            APPLICATION: "<< parameters.application >>"
-            GOFLAGS: "-p=4"
+            APPLICATION: '<< parameters.application >>'
+            GOFLAGS: '-p=4'
       - run:
           name: make db_test_reset for <<parameters.application>>
           command: make db_test_reset
           environment:
-            APPLICATION: "<< parameters.application >>"
+            APPLICATION: '<< parameters.application >>'
             DB_PASSWORD: mysecretpassword
             DB_USER: postgres
             DB_HOST: localhost
@@ -215,7 +215,7 @@ commands:
           name: make db_test_migrate for <<parameters.application>>
           command: make db_test_migrate
           environment:
-            APPLICATION: "<< parameters.application >>"
+            APPLICATION: '<< parameters.application >>'
             DB_PASSWORD: mysecretpassword
             DB_USER: postgres
             DB_HOST: localhost
@@ -232,7 +232,7 @@ commands:
             source $BASH_ENV
             make server_test_standalone
           environment:
-            APPLICATION: "<< parameters.application >>"
+            APPLICATION: '<< parameters.application >>'
             DB_PASSWORD: mysecretpassword
             DB_USER: postgres
             DB_HOST: localhost
@@ -243,7 +243,7 @@ commands:
             EIA_KEY: db2522a43820268a41a802a16ae9fd26 # dummy key generated with openssl rand -hex 16
             ENV: test
             ENVIRONMENT: test
-            GOFLAGS: "-p=4"
+            GOFLAGS: '-p=4'
             JUNIT: 1
             MIGRATION_MANIFEST: '/home/circleci/milmove_orders/migrations/<< parameters.application >>/migrations_manifest.txt'
             MIGRATION_PATH: 'file:///home/circleci/milmove_orders/migrations/<< parameters.application >>/schema;file:///home/circleci/milmove_orders/migrations/<< parameters.application >>/secure'
@@ -465,7 +465,7 @@ jobs:
       - run: make bin/health-checker
       - run: make bin/tls-checker
       - persist_to_workspace:
-          root:  /home/circleci/milmove_orders/bin
+          root: /home/circleci/milmove_orders/bin
           paths:
             - ecs-deploy # for registering task defs and deploying task container
             - health-checker # for health check after deploy
@@ -559,7 +559,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: am-remove-lee-cac-access
 
       - server_test:
           requires:
@@ -567,7 +567,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: am-remove-lee-cac-access
 
       - build_orders:
           requires:
@@ -595,14 +595,14 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: am-remove-lee-cac-access
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: am-remove-lee-cac-access
 
 experimental:
   notify:

--- a/migrations/orders/migrations_manifest.txt
+++ b/migrations/orders/migrations_manifest.txt
@@ -18,3 +18,4 @@
 20200219000003_rd_cac.up.sql
 20200619120000_remove_cgilmer_cac.up.sql
 20200929210500_remove_rdhariwal_cac.up.sql
+20201103125136_remove_mr337_cac.up.sql

--- a/migrations/orders/schema/20201103125136_remove_mr337_cac.up.sql
+++ b/migrations/orders/schema/20201103125136_remove_mr337_cac.up.sql
@@ -1,0 +1,2 @@
+-- Remove mr337 CAC using unique sha256 digest of client cert
+DELETE FROM client_certs WHERE sha256_digest='6f684e8ed9f697a5b6099f31f5346042db6339ecd8029000df8924369defb069';


### PR DESCRIPTION
## Description

Removes CAC access. This doesn't have to be a secure migration because we're only identifying the sha256 digest in dev/experimental/staging/prod. And if it doesn't exist in those environments this is a noop.

## Reviewer Notes

NOTE: This needs to be deployed manually to experimental to apply in that environment.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_run db_dev_migrate
```

